### PR TITLE
Add gastald values and use network param

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -55,7 +55,7 @@ export interface AddressesResponse {
 export async function fetchAddressMetadata(
   chainConfig: BlockchainConfig,
   toAddress: string,
-  network: NetworkParams = Networks.mainnet,
+  network: NetworkParams,
 ): Promise<AddressesResponse> {
   try {
     const url = `${network === Networks.mainnet ? MAINNET_URL : GASTALD_URL}${chainConfig.name}/${toAddress}`;

--- a/src/chain-id.ts
+++ b/src/chain-id.ts
@@ -24,8 +24,8 @@ export enum SupportedBlockchains {
   Katana = "katana",
 }
 
-// Blockchain configuration map
-export const blockchainConfigMap = new Map([
+// Blockchain configuration map for mainnet
+export const mainnetBlockchainConfigs = new Map([
   [
     SupportedBlockchains.Ethereum,
     {
@@ -44,7 +44,7 @@ export const blockchainConfigMap = new Map([
     SupportedBlockchains.Base,
     {
       chainId: Buffer.from(
-        "0000000000000000000000000000000000000000000000000000000000000038",
+        "0000000000000000000000000000000000000000000000000000000000002105",
         "hex",
       ),
       stlbtc: Buffer.from("ecAc9C5F704e954931349Da37F60E39f515c11c1", "hex"),
@@ -147,6 +147,129 @@ export const blockchainConfigMap = new Map([
   ],
 ]);
 
+// Blockchain configuration map for Gastald testnet
+export const gastaldBlockchainConfigs = new Map([
+  [
+    SupportedBlockchains.Ethereum,
+    {
+      chainId: Buffer.from(
+        "0000000000000000000000000000000000000000000000000000000000004268",
+        "hex",
+      ),
+      stlbtc: Buffer.from("38A13AB20D15ffbE5A7312d2336EF1552580a4E2", "hex"),
+      nativeLbtc: null,
+      name: "DESTINATION_BLOCKCHAIN_ETHEREUM",
+      ecosystem: Ecosystem.EVM,
+    },
+  ],
+
+  [
+    SupportedBlockchains.Base,
+    {
+      chainId: Buffer.from(
+        "0000000000000000000000000000000000000000000000000000000000014a34",
+        "hex",
+      ),
+      stlbtc: Buffer.from("107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5", "hex"),
+      nativeLbtc: null,
+      name: "DESTINATION_BLOCKCHAIN_BASE",
+      ecosystem: Ecosystem.EVM,
+    },
+  ],
+
+  [
+    SupportedBlockchains.BSC,
+    {
+      chainId: Buffer.from(
+        "0000000000000000000000000000000000000000000000000000000000000061",
+        "hex",
+      ),
+      stlbtc: Buffer.from("107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5", "hex"),
+      nativeLbtc: null,
+      name: "DESTINATION_BLOCKCHAIN_BSC",
+      ecosystem: Ecosystem.EVM,
+    },
+  ],
+
+  [
+    SupportedBlockchains.Sui,
+    {
+      chainId: Buffer.from(
+        "010000000000000000000000000000000000000000000000000000004c78adac",
+        "hex",
+      ),
+      stlbtc: Buffer.from(
+        "50454d0b0fbad1288a6ab74f2e8ce0905a3317870673ab7787ebcf6f322b45fa",
+        "hex",
+      ),
+      nativeLbtc: null,
+      name: "DESTINATION_BLOCKCHAIN_SUI",
+      ecosystem: Ecosystem.Sui,
+    },
+  ],
+
+  [
+    SupportedBlockchains.Sonic,
+    {
+      chainId: Buffer.from(
+        "000000000000000000000000000000000000000000000000000000000000dede",
+        "hex",
+      ),
+      stlbtc: Buffer.from("107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5", "hex"),
+      nativeLbtc: null,
+      name: "DESTINATION_BLOCKCHAIN_SONIC",
+      ecosystem: Ecosystem.EVM,
+    },
+  ],
+
+  [
+    SupportedBlockchains.Ink,
+    {
+      chainId: Buffer.from(
+        "00000000000000000000000000000000000000000000000000000000000ba5ed",
+        "hex",
+      ),
+      stlbtc: Buffer.from("107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5", "hex"),
+      nativeLbtc: null,
+      name: "DESTINATION_BLOCKCHAIN_INK",
+      ecosystem: Ecosystem.EVM,
+    },
+  ],
+
+  [
+    SupportedBlockchains.Solana,
+    {
+      chainId: Buffer.from(
+        "0259db5080fc2c6d3bcf7ca90712d3c2e5e6c28f27f0dfbb9953bdb0894c03ab",
+        "hex",
+      ),
+      stlbtc: Buffer.from(
+        bs58.decode("79cscM6J9Af24TGGWcXyDf56fDLoodkyXdVy4R9aZ6C6"),
+      ),
+      nativeLbtc: null,
+      name: "DESTINATION_BLOCKCHAIN_SOLANA",
+      ecosystem: Ecosystem.Solana,
+    },
+  ],
+
+  [
+    SupportedBlockchains.Katana,
+    {
+      chainId: Buffer.from(
+        "000000000000000000000000000000000000000000000000000000000001f977",
+        "hex",
+      ),
+      stlbtc: Buffer.from("107Fc7d90484534704dD2A9e24c7BD45DB4dD1B5", "hex"),
+      nativeLbtc: Buffer.from(
+        "20eA7b8ABb4B583788F1DFC738C709a2d9675681",
+        "hex",
+      ),
+      name: "DESTINATION_BLOCKCHAIN_KATANA",
+      ecosystem: Ecosystem.EVM,
+    },
+  ],
+]);
+
 // Type definition for the config structure
 export interface BlockchainConfig {
   chainId: LChainId;
@@ -154,11 +277,4 @@ export interface BlockchainConfig {
   nativeLbtc: Address | null;
   name: string;
   ecosystem: Ecosystem;
-}
-
-// Helper function to get config for a blockchain
-export function getBlockchainConfig(
-  blockchain: SupportedBlockchains,
-): BlockchainConfig | undefined {
-  return blockchainConfigMap.get(blockchain);
 }

--- a/src/deposit-address.ts
+++ b/src/deposit-address.ts
@@ -46,7 +46,7 @@ const SOLANA_GASTALD_MINT_ADDRESS =
 
 // Config type
 export interface Config {
-  network: "mainnet" | "signet";
+  network: NetworkParams;
   depositPublicKey: Buffer;
 }
 
@@ -165,26 +165,13 @@ export class AddressService {
   private network: NetworkParams;
 
   constructor(config: Config) {
-    let network: NetworkParams;
-
-    switch (config.network) {
-      case "mainnet":
-        network = Networks.mainnet;
-        break;
-      case "signet":
-        network = Networks.signet;
-        break;
-      default:
-        throw new BitcoinAddressError(`Unknown network: '${config.network}'`);
-    }
-
     try {
       this.tweaker = new Tweaker(config.depositPublicKey);
     } catch (error) {
       throw new BitcoinAddressError("Bad public deposit key");
     }
 
-    this.network = network;
+    this.network = config.network;
   }
 
   /**
@@ -251,7 +238,7 @@ export async function calculateDeterministicAddress(
   network: NetworkParams = Networks.mainnet,
 ): Promise<AddressCalculationResult> {
   let config: Config = {
-    network: "mainnet",
+    network: network,
     depositPublicKey:
       network === Networks.mainnet ? MAINNET_PUBLIC_KEY : GASTALD_PUBLIC_KEY,
   };

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,9 +1,6 @@
-import {
-  calculateDeterministicAddress,
-  MAINNET_PUBLIC_KEY,
-} from "./deposit-address";
+import { calculateDeterministicAddress } from "./deposit-address";
 import { SupportedBlockchains } from "./chain-id";
-import { BitcoinAddressError } from "./bitcoin";
+import { BitcoinAddressError, Networks } from "./bitcoin";
 import { APIError } from "./api";
 
 // Example usage
@@ -20,7 +17,7 @@ async function generateSegwitAddress() {
       const match = await calculateDeterministicAddress(
         chain,
         toAddress,
-        MAINNET_PUBLIC_KEY,
+        Networks.mainnet,
       );
 
       console.log("Match:", match);
@@ -37,7 +34,7 @@ async function generateSegwitAddress() {
       const match = await calculateDeterministicAddress(
         chain,
         toAddress,
-        MAINNET_PUBLIC_KEY,
+        Networks.mainnet,
       );
 
       console.log("Match:", match);
@@ -54,7 +51,7 @@ async function generateSegwitAddress() {
       const match = await calculateDeterministicAddress(
         chain,
         toAddress,
-        MAINNET_PUBLIC_KEY,
+        Networks.mainnet,
       );
 
       console.log("Match:", match);
@@ -72,7 +69,7 @@ async function generateSegwitAddress() {
       const match = await calculateDeterministicAddress(
         chain,
         toAddress,
-        MAINNET_PUBLIC_KEY,
+        Networks.mainnet,
       );
 
       console.log("Match:", match);

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -1,9 +1,6 @@
-import { BitcoinAddressError } from "./bitcoin";
+import { BitcoinAddressError, Networks } from "./bitcoin";
 import { SupportedBlockchains } from "./chain-id";
-import {
-  calculateDeterministicAddress,
-  MAINNET_PUBLIC_KEY,
-} from "./deposit-address";
+import { calculateDeterministicAddress } from "./deposit-address";
 
 async function main() {
   const blockchain = process.argv[2];
@@ -43,7 +40,7 @@ async function main() {
   const results = await calculateDeterministicAddress(
     blockchainType,
     toAddress,
-    MAINNET_PUBLIC_KEY,
+    Networks.mainnet,
   );
 
   results.addresses.forEach((addr, i) => {

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -1,4 +1,4 @@
-import { BitcoinAddressError, Networks } from "./bitcoin";
+import { BitcoinAddressError, Networks, NetworkParams } from "./bitcoin";
 import { SupportedBlockchains } from "./chain-id";
 import { calculateDeterministicAddress } from "./deposit-address";
 
@@ -37,10 +37,22 @@ async function main() {
   }
 
   const toAddress = process.argv[3];
+
+  const network =
+    process.argv[4] === "signet"
+      ? Networks.signet
+      : process.argv[4] === "mainnet" || !process.argv[4]
+        ? Networks.mainnet
+        : (() => {
+            throw new BitcoinAddressError(
+              `Unknown network: '${process.argv[4]}'`,
+            );
+          })();
+
   const results = await calculateDeterministicAddress(
     blockchainType,
     toAddress,
-    Networks.mainnet,
+    network,
   );
 
   results.addresses.forEach((addr, i) => {


### PR DESCRIPTION
- Added Gastald values for chains, Solana mint address, API URL
- Fixed mainnet Base chain id
- Moved `toAddress` resolution (from hex string or using Solana mint address) to `deposit-address.ts` because it's not specific to our API, this resolution would need to be done regardless of how the address metadata was retrieved